### PR TITLE
LIBASPACE-41 Update plugin to work with v2.1.2

### DIFF
--- a/frontend/plugin_init.rb
+++ b/frontend/plugin_init.rb
@@ -1,5 +1,5 @@
 my_routes = [File.join(File.dirname(__FILE__), "routes.rb")]
-ArchivesSpace::Application.config.paths['config/routes'].concat(my_routes)
+ArchivesSpace::Application.extend_aspace_routes(File.join(File.dirname(__FILE__), "routes.rb"))                                                               
 
 Rails.application.config.after_initialize do
   UsersController.class_eval do


### PR DESCRIPTION
This updates the plugin to work with the newer version of ASPACE (
v2.1.2 )

https://issues.umd.edu/browse/LIBASPACE-41